### PR TITLE
Preventing pd from crashing when using gem with ggee/shell (linux)

### DIFF
--- a/control/shell.c
+++ b/control/shell.c
@@ -24,7 +24,7 @@ void sys_addpollfn(int fd, void* fn, void *ptr);
 static t_class *shell_class;
 
 
-static void drop_priority(void) 
+static void drop_priority(void)
 {
 #if (_POSIX_PRIORITY_SCHEDULING - 0) >=  200112L
     struct sched_param par;
@@ -167,7 +167,7 @@ void shell_read(t_shell *x, int fd)
 	 int natom;
 	 t_atom *at;
 	 binbuf_text(bbuf, buf, strlen(buf));
-	 
+
 	 natom = binbuf_getnatom(bbuf);
 	 at = binbuf_getvec(bbuf);
 	 shell_doit(x,bbuf);
@@ -188,10 +188,10 @@ static void shell_send(t_shell *x, t_symbol *s,int ac, t_atom *at)
 	  atom_string(at,tmp+size,MAXPDSTRING - size);
 	  at++;
 	  size=strlen(tmp);
-	  tmp[size++] = ' ';	  
+	  tmp[size++] = ' '; 
      }
      tmp[size-1] = '\0';
-     post("sending %s",tmp); 
+     post("sending %s",tmp);
      write(x->fdinpipe[0],tmp,strlen(tmp));
 }
 
@@ -209,7 +209,7 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
 
      argv[0] = s->s_name;
 
-     if (x->fdpipe[0] != -1) { 
+     if (x->fdpipe[0] != -1) {
 	  post("shell: old process still running");
 	  kill(x->pid,SIGKILL);
 	  shell_cleanup(x);
@@ -233,7 +233,7 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
          /* reassign stdout */
          dup2(x->fdpipe[1],1);
          dup2(x->fdinpipe[1],0);
-         
+
          /* drop privileges */
          drop_priority();
          seteuid(getuid());          /* lose setuid priveliges */
@@ -247,19 +247,8 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
 	  argv[i] = 0;
 	  execvp(s->s_name,argv);
 #else
-/*	  char* cmd = getbytes(1024);
-	  char* tcmd = getbytes(1024);
-	  strcpy(cmd,s->s_name);
-      for (i=1;i<=ac;i++) {
-	       atom_string(at,tcmd,255);
-	       strcat(cmd," ");
-               strcat(cmd,tcmd);
-               at++;
-	  }
-	  verbose(4,"executing %s",cmd);
-	  
-	system(cmd);
-*/
+	// changed linux part: use execvp() instead system()
+	// see https://github.com/umlaeute/Gem/issues/224
 
 	  for (i=1;i<=ac;i++) {
 	       argv[i] = getbytes(255);

--- a/control/shell.c
+++ b/control/shell.c
@@ -24,7 +24,7 @@ void sys_addpollfn(int fd, void* fn, void *ptr);
 static t_class *shell_class;
 
 
-static void drop_priority(void)
+static void drop_priority(void) 
 {
 #if (_POSIX_PRIORITY_SCHEDULING - 0) >=  200112L
     struct sched_param par;
@@ -167,7 +167,7 @@ void shell_read(t_shell *x, int fd)
 	 int natom;
 	 t_atom *at;
 	 binbuf_text(bbuf, buf, strlen(buf));
-
+	 
 	 natom = binbuf_getnatom(bbuf);
 	 at = binbuf_getvec(bbuf);
 	 shell_doit(x,bbuf);
@@ -188,10 +188,10 @@ static void shell_send(t_shell *x, t_symbol *s,int ac, t_atom *at)
 	  atom_string(at,tmp+size,MAXPDSTRING - size);
 	  at++;
 	  size=strlen(tmp);
-	  tmp[size++] = ' ';
+	  tmp[size++] = ' ';	  
      }
      tmp[size-1] = '\0';
-     post("sending %s",tmp);
+     post("sending %s",tmp); 
      write(x->fdinpipe[0],tmp,strlen(tmp));
 }
 
@@ -209,7 +209,7 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
 
      argv[0] = s->s_name;
 
-     if (x->fdpipe[0] != -1) {
+     if (x->fdpipe[0] != -1) { 
 	  post("shell: old process still running");
 	  kill(x->pid,SIGKILL);
 	  shell_cleanup(x);
@@ -233,7 +233,7 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
          /* reassign stdout */
          dup2(x->fdpipe[1],1);
          dup2(x->fdinpipe[1],0);
-
+         
          /* drop privileges */
          drop_priority();
          seteuid(getuid());          /* lose setuid priveliges */
@@ -247,7 +247,7 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
 	  argv[i] = 0;
 	  execvp(s->s_name,argv);
 #else
-	  char* cmd = getbytes(1024);
+/*	  char* cmd = getbytes(1024);
 	  char* tcmd = getbytes(1024);
 	  strcpy(cmd,s->s_name);
       for (i=1;i<=ac;i++) {
@@ -257,7 +257,17 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
                at++;
 	  }
 	  verbose(4,"executing %s",cmd);
-	  system(cmd);
+	  
+	system(cmd);
+*/
+
+	  for (i=1;i<=ac;i++) {
+	       argv[i] = getbytes(255);
+	       atom_string(at,argv[i],255);
+	       at++;
+	  }
+	  argv[i] = 0;
+	  execvp(s->s_name,argv);
 #endif /* __APPLE__ */
 	  exit(0);
      }
@@ -265,7 +275,7 @@ static void shell_anything(t_shell *x, t_symbol *s, int ac, t_atom *at)
      clock_delay(x->x_clock,x->x_del);
 
      if (x->x_echo)
-	  outlet_anything(x->x_obj.ob_outlet, s, ac, at);
+	  outlet_anything(x->x_obj.ob_outlet, s, ac, at); 
 }
 
 
@@ -298,7 +308,7 @@ static void *shell_new(void)
 
 void shell_setup(void)
 {
-    shell_class = class_new(gensym("shell"), (t_newmethod)shell_new,
+    shell_class = class_new(gensym("shell"), (t_newmethod)shell_new, 
 			    (t_method)shell_free,sizeof(t_shell), 0,0);
     class_addbang(shell_class,shell_bang);
     class_addanything(shell_class, shell_anything);
@@ -306,3 +316,5 @@ void shell_setup(void)
 
 
 #endif /* _WIN32 */
+
+


### PR DESCRIPTION
According to discussion [https://github.com/umlaeute/Gem/issues/224] I replaced `system()` by ` execvp()`   in  shell.c to prevent pd from crashing when gem and ggee/shell are used in the same pd instance.