### PR TITLE
Update/warning fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# builds
+*.pd_linux
+*.pd_darwin
+*.dll
+*.o
+*.so
+*.dylib

--- a/control/sinh.c
+++ b/control/sinh.c
@@ -35,7 +35,7 @@ void sinh_float(t_sinh *x,t_floatarg f)
 }
 
 
-static void *sinh_new()
+static void *sinh_new(void)
 {
     t_sinh *x = (t_sinh *)pd_new(sinh_class);
 

--- a/control/stripdir.c
+++ b/control/stripdir.c
@@ -21,7 +21,7 @@ typedef struct _stripdir
 
 void stripdir_symbol(t_stripdir *x,t_symbol* s)
 {
-     int len = strlen(s->s_name);
+     int len = (int)strlen(s->s_name);
 
      while (len--)
           if (*(s->s_name + len) == '/') {

--- a/control/stripdir.c
+++ b/control/stripdir.c
@@ -31,7 +31,7 @@ void stripdir_symbol(t_stripdir *x,t_symbol* s)
 
 }
 
-static void *stripdir_new()
+static void *stripdir_new(void)
 {
     t_stripdir *x = (t_stripdir *)pd_new(stripdir_class);
     outlet_new(&x->x_obj, &s_float);

--- a/experimental/pvocfreq.c
+++ b/experimental/pvocfreq.c
@@ -89,7 +89,7 @@ static void shuffle_dsp(t_shuffle *x, t_signal **sp)
 
 }
 
-static void *shuffle_new()
+static void *shuffle_new(void)
 {
     t_shuffle *x = (t_shuffle *)pd_new(shuffle_class);
 

--- a/gui/fatom.c
+++ b/gui/fatom.c
@@ -4,7 +4,7 @@
 
 static t_class *fatom_class;
 
-void fatom_setup() {
+void fatom_setup(void) {
   post("fatom setup");
     fatom_class = class_new(gensym("fatom"), (t_newmethod)fatom_new, 0,
                                 sizeof(t_fatom),0,A_DEFSYM,0);

--- a/gui/slider.c
+++ b/gui/slider.c
@@ -28,7 +28,7 @@ static void *slider_new(t_floatarg max, t_floatarg min, t_floatarg h)
 t_widgetbehavior   slider_widgetbehavior;
 
 
-void slider_setup() {
+void slider_setup(void) {
     slider_class = class_new(gensym("slider"), (t_newmethod)slider_new, 0,
                                 sizeof(t_fatom),0,A_DEFFLOAT,A_DEFFLOAT,A_DEFFLOAT,0);
 

--- a/gui/sliderh.c
+++ b/gui/sliderh.c
@@ -39,7 +39,7 @@ t_widgetbehavior   sliderh_widgetbehavior;
 
 
 
-void sliderh_setup() {
+void sliderh_setup(void) {
     sliderh_class = class_new(gensym("sliderh"), (t_newmethod)sliderh_new, 0,
                                 sizeof(t_fatom),0,A_DEFFLOAT,A_DEFFLOAT,A_DEFFLOAT,0);
 

--- a/gui/ticker.c
+++ b/gui/ticker.c
@@ -42,7 +42,7 @@ static void *ticker_new(t_symbol* t)
 t_widgetbehavior   ticker_widgetbehavior;
 
 
-void ticker_setup() {
+void ticker_setup(void) {
     ticker_class = class_new(gensym("ticker"), (t_newmethod)ticker_new, 0,
                                 sizeof(t_fatom),0,A_DEFSYMBOL,0);
 

--- a/other/messages.c
+++ b/other/messages.c
@@ -23,7 +23,7 @@ void messages_bang(t_messages *x)
      post("bang");
 }
 
-static void *messages_new()
+static void *messages_new(void)
 {
     t_messages *x = (t_messages *)pd_new(messages_class);
     outlet_new(&x->x_obj, &s_float);


### PR DESCRIPTION
This PR fixes a few warnings in some externals I use in PdParty as well as fixes the "A function declaration without a prototype is deprecated in all versions of C" by adding `void` to those externals `_setup()` and `_new()` func declarations. I also added a gitignore file.

note: This doesn't fix all warnings, of which there are many...